### PR TITLE
Humanize market cap by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ program
   .option('-c, --convert [currency]', 'Convert to your fiat currency', 'usd')
   .option('-f, --find [keyword]', 'Find specific coin data with coin symbol or name', null)
   .option('-t, --top [index]', 'Show the top coins ranked from 1 - [index] according to the market cap', null)
-  .option('-H, --humanize', 'Show market cap as a humanized number', false)
+  .option('-H, --humanize', 'Show market cap as a humanized number', true)
   .parse(process.argv);
 
 const find = program.find


### PR DESCRIPTION
This is a proposal to set the default to true. Its really hard to make any sense of the market cap numbers without formatting since they are so large. Another possibility would be to remove the option entirely since I'm not sure when anybody would not want this since its a visual tool for human consumption.

If not could you explain the reasoning?