### PR TITLE
Adding required "colors": "^1.1.2" to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,8 +170,7 @@
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "optional": true
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "commander": {
       "version": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "axios": "^0.17.1",
     "cfonts": "^1.1.3",
     "cli-table2": "^0.2.0",
+    "colors": "^1.1.2",
     "commander": "^2.11.0",
     "humanize-plus": "^1.8.2",
     "ora": "^1.3.0"


### PR DESCRIPTION
Adding in "colors": "^1.1.2" to package.json for compatibility with various Linux distributions. 