### PR TITLE
Adding '--columns' option to display $COLUMNS results per row

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,21 @@ const os = require('os')
 
 const platform = os.platform() // linux, darwin, win32, sunos
 const supportEmoji = platform !== 'darwin'
-const list = val => val.split(',')
+const list = val => val.split(',');
+
+transpose = function(array, n) {
+  var records = [];
+  if (n > array.length) {
+    return undefined;
+  }
+  var grouped = Math.floor(array.length / n);
+  for(var j = 0; j < n; j++) {
+    for(var i = 0; i < grouped; i++) {
+      records[i * n + j] = (array[j * grouped + i]);
+    }
+  }
+  return records;
+}
 
 program
   .version('0.0.9')
@@ -103,8 +117,13 @@ axios.get(sourceUrl)
       for(var i = 1; i < columns; i++) {
         table.options.head = table.options.head.concat(defaultHeader);
       }
-      for(var i = 0; i < records.length; i+=columns) {
-        table.push(records.slice(i, i+columns).reduce(function( a,rec ) { a.push(...rec); return a; }, []));
+      var transposed = transpose(records, columns);
+      var remainder = records.length % columns
+      for(var i = 0; i < transposed.length; i+=columns) {
+        table.push(transposed.slice(i, i+columns).reduce(function( a,rec ) { a.push(...rec); return a; }, []));
+      }
+      for(var i = 0; i < remainder; i++) {
+        table.push(Array.from('-'.repeat(( columns - 1 ) * defaultHeader.length)).concat(records[transposed.length + i]))
       }
     } else {
       records.forEach(record => table.push(record))


### PR DESCRIPTION
![coinmon-vertical-ordering](https://user-images.githubusercontent.com/1153041/34324694-bf35a9aa-e862-11e7-8388-62c871c9072f.png)


--
Previous screenshot:

![coinmon-3-column](https://user-images.githubusercontent.com/1153041/34308997-038aa876-e737-11e7-98d2-e63c85ed0706.png)

This one doesn't make sense anymore because the latest commit added code to ensure cryptos are vertically ordered.