### PR TITLE
Add customizable paths for portfolio config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ And you can use vim or editors to input your portfolio
 ```
 
 ```
-$ coinmon -p
+$ coinmon -p // Retrieve the portfolio from $HOME/.coinmon/portfolio.json
+$ coinmon -p /anotherDir/myportfolio.json // Retrieve the portfolio from specified directory
 ```
 
 ### Show specific columns

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ program
   .option('-c, --convert [currency]', 'Convert to your currency', validation.validateConvertCurrency, 'USD')
   .option('-f, --find [symbol]', 'Find specific coin data with coin symbol (can be a comma seperated list)', list, [])
   .option('-t, --top [index]', 'Show the top coins ranked from 1 - [index] according to the market cap', validation.validateNumber, 10)
-  .option('-p, --portfolio', 'Retrieve coins specified in $HOME/.coinmon/portfolio.json file', validation.validatePorfolioConfigPath)
+  .option('-p, --portfolio [portfolioPath]', 'Retrieve coins specified in $HOME/.coinmon/portfolio.json file', validation.validatePorfolioConfigPath)
   .option('-s, --specific [index]', 'Display specific columns (can be a comma seperated list)', list, [])
   .option('-r, --rank [index]', 'Sort specific column', validation.validateNumber, 0)
   .parse(process.argv)

--- a/src/validation.js
+++ b/src/validation.js
@@ -9,13 +9,13 @@ module.exports = {
     }
     return +value
   },
-  validatePorfolioConfigPath : () => {
-    const path = constants.portfolioPath
+  validatePorfolioConfigPath : (customPath) => {
+    const path = customPath || constants.portfolioPath
     if (!fs.existsSync(path)) {
       console.log(`Please include a configuration file at ${path}.`.red)
       process.exit()
     }
-    return true
+    return path
   },
   validateConvertCurrency : (value) => {
     const convert = value.toUpperCase()


### PR DESCRIPTION
There was an issue where a windows user could make the portfolio feature work because of the
hardcoded linux directory. Thus we made the portfolio directory customizable with fallback
address the hardcoded linux directory. Maybe we should identify the OS of the user and
set different fallback dirs for different OS. We'll see what the future holds.